### PR TITLE
Add Node.js backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # unipasaport
+
+## Backend
+
+Node.js + Express tabanlı API `/backend` dizini altında yer alır.
+
+### Kurulum
+
+```bash
+cd backend
+npm install
+cp .env.example .env
+# .env dosyasındaki değerleri güncelleyin
+npm run dev
+```
+
+### Özellikler
+
+- Kullanıcı kayıt ve login (JWT ile)
+- Ders (Course) ve konu (Topic) modelleri
+- Videoların ders ve konuya bağlı şekilde eklenmesi
+- Filtreli listeleme endpoint'leri
+
+### Önemli Scriptler
+
+- `npm run dev` – Nodemon ile geliştirme sunucusunu başlatır.
+- `npm start` – Üretim sunucusunu başlatır.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://localhost:27017/unipasaport
+JWT_SECRET=your_jwt_secret
+PORT=5000

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(process.env.MONGO_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    });
+    console.log('MongoDB connected');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+};
+
+module.exports = connectDB;

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+exports.register = async (req, res) => {
+  try {
+    const user = await User.create(req.body);
+    res.status(201).json(user);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.login = async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+    const isMatch = await user.matchPassword(password);
+    if (!isMatch) return res.status(400).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '1d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -1,0 +1,19 @@
+const Course = require('../models/Course');
+
+exports.createCourse = async (req, res) => {
+  try {
+    const course = await Course.create(req.body);
+    res.status(201).json(course);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getCourses = async (req, res) => {
+  try {
+    const courses = await Course.find();
+    res.json(courses);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/controllers/topicController.js
+++ b/backend/controllers/topicController.js
@@ -1,0 +1,23 @@
+const Topic = require('../models/Topic');
+
+exports.createTopic = async (req, res) => {
+  try {
+    const topic = await Topic.create(req.body);
+    res.status(201).json(topic);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getTopics = async (req, res) => {
+  const filter = {};
+  if (req.query.course) {
+    filter.course = req.query.course;
+  }
+  try {
+    const topics = await Topic.find(filter).populate('course');
+    res.json(topics);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/controllers/videoController.js
+++ b/backend/controllers/videoController.js
@@ -1,0 +1,22 @@
+const Video = require('../models/Video');
+
+exports.createVideo = async (req, res) => {
+  try {
+    const video = await Video.create(req.body);
+    res.status(201).json(video);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getVideos = async (req, res) => {
+  const filter = {};
+  if (req.query.course) filter.course = req.query.course;
+  if (req.query.topic) filter.topic = req.query.topic;
+  try {
+    const videos = await Video.find(filter).populate('course').populate('topic');
+    res.json(videos);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const token = req.header('Authorization')?.replace('Bearer ', '');
+  if (!token) return res.status(401).json({ message: 'No token, authorization denied' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Token is not valid' });
+  }
+};

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+
+const CourseSchema = new mongoose.Schema({
+  name: { type: String, required: true }
+});
+
+module.exports = mongoose.model('Course', CourseSchema);

--- a/backend/models/Topic.js
+++ b/backend/models/Topic.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const TopicSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  course: { type: mongoose.Schema.Types.ObjectId, ref: 'Course', required: true }
+});
+
+module.exports = mongoose.model('Topic', TopicSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+const UserSchema = new mongoose.Schema({
+  username: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
+});
+
+UserSchema.methods.matchPassword = function (enteredPassword) {
+  return bcrypt.compare(enteredPassword, this.password);
+};
+
+module.exports = mongoose.model('User', UserSchema);

--- a/backend/models/Video.js
+++ b/backend/models/Video.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const VideoSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  description: { type: String },
+  videoUrl: { type: String, required: true },
+  course: { type: mongoose.Schema.Types.ObjectId, ref: 'Course', required: true },
+  topic: { type: mongoose.Schema.Types.ObjectId, ref: 'Topic', required: true }
+});
+
+module.exports = mongoose.model('Video', VideoSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.4",
+    "dotenv": "^16.0.3",
+    "jsonwebtoken": "^9.0.0",
+    "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { register, login } = require('../controllers/authController');
+
+router.post('/register', register);
+router.post('/login', login);
+
+module.exports = router;

--- a/backend/routes/courses.js
+++ b/backend/routes/courses.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { createCourse, getCourses } = require('../controllers/courseController');
+const auth = require('../middleware/auth');
+
+router.post('/', auth, createCourse);
+router.get('/', getCourses);
+
+module.exports = router;

--- a/backend/routes/topics.js
+++ b/backend/routes/topics.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { createTopic, getTopics } = require('../controllers/topicController');
+const auth = require('../middleware/auth');
+
+router.post('/', auth, createTopic);
+router.get('/', getTopics);
+
+module.exports = router;

--- a/backend/routes/videos.js
+++ b/backend/routes/videos.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { createVideo, getVideos } = require('../controllers/videoController');
+const auth = require('../middleware/auth');
+
+router.post('/', auth, createVideo);
+router.get('/', getVideos);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const authRoutes = require('./routes/auth');
+const courseRoutes = require('./routes/courses');
+const topicRoutes = require('./routes/topics');
+const videoRoutes = require('./routes/videos');
+
+const app = express();
+
+dotenv.config();
+
+const connectDB = require('./config/db');
+connectDB();
+
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/courses', courseRoutes);
+app.use('/api/topics', topicRoutes);
+app.use('/api/videos', videoRoutes);
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- scaffold an Express API in `backend`
- add MongoDB models for courses, topics, users, and videos
- implement authentication with JWT and protect create routes
- set up filtering for topics and videos
- document setup in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68401620fce88328a0454fb1cd35b7bd