### PR TITLE
Add React admin panel

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,26 @@
+# Admin Panel
+
+This is a minimal React.js admin panel for managing courses, topics and videos.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm start
+```
+
+The app expects the backend API to provide the following endpoints:
+
+- `POST /api/auth/login` returns `{ token: "JWT" }`.
+- `GET/POST/DELETE /api/courses`
+- `GET/POST/DELETE /api/topics`
+- `GET/POST/DELETE /api/videos`
+
+The JWT token is stored in `localStorage` and sent as `Authorization: Bearer <token>` in each request.

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "admin-panel",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/admin/src/App.css
+++ b/admin/src/App.css
@@ -1,0 +1,17 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+.App form {
+  margin-bottom: 20px;
+}
+
+.App input {
+  margin-right: 10px;
+}
+
+.App ul {
+  list-style: none;
+  padding: 0;
+}

--- a/admin/src/App.js
+++ b/admin/src/App.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import Login from './components/Login';
+import CourseManager from './components/CourseManager';
+import TopicManager from './components/TopicManager';
+import VideoManager from './components/VideoManager';
+
+function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  if (!token) {
+    return <Login onLogin={setToken} />;
+  }
+
+  return (
+    <div className="App">
+      <h1>Admin Panel</h1>
+      <button onClick={() => {
+        localStorage.removeItem('token');
+        setToken(null);
+      }}>Logout</button>
+      <CourseManager token={token} />
+      <TopicManager token={token} />
+      <VideoManager token={token} />
+    </div>
+  );
+}
+
+export default App;

--- a/admin/src/api.js
+++ b/admin/src/api.js
@@ -1,0 +1,20 @@
+export async function login(username, password) {
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+  const data = await res.json();
+  localStorage.setItem('token', data.token);
+  return data.token;
+}
+
+export async function request(url, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = options.headers || {};
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return fetch(url, { ...options, headers });
+}

--- a/admin/src/components/CourseManager.js
+++ b/admin/src/components/CourseManager.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { request } from '../api';
+
+function CourseManager({ token }) {
+  const [courses, setCourses] = useState([]);
+  const [name, setName] = useState('');
+
+  const load = async () => {
+    const res = await request('/api/courses');
+    if (res.ok) setCourses(await res.json());
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const addCourse = async (e) => {
+    e.preventDefault();
+    await request('/api/courses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    setName('');
+    load();
+  };
+
+  const deleteCourse = async (id) => {
+    await request(`/api/courses/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Courses</h2>
+      <form onSubmit={addCourse}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Course name"
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {courses.map((c) => (
+          <li key={c.id}>
+            {c.name}
+            <button onClick={() => deleteCourse(c.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CourseManager;

--- a/admin/src/components/Login.js
+++ b/admin/src/components/Login.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { login } from '../api';
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const token = await login(username, password);
+      onLogin(token);
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Login</button>
+        {error && <p>{error}</p>}
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/admin/src/components/TopicManager.js
+++ b/admin/src/components/TopicManager.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { request } from '../api';
+
+function TopicManager({ token }) {
+  const [topics, setTopics] = useState([]);
+  const [title, setTitle] = useState('');
+
+  const load = async () => {
+    const res = await request('/api/topics');
+    if (res.ok) setTopics(await res.json());
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const addTopic = async (e) => {
+    e.preventDefault();
+    await request('/api/topics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title })
+    });
+    setTitle('');
+    load();
+  };
+
+  const deleteTopic = async (id) => {
+    await request(`/api/topics/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Topics</h2>
+      <form onSubmit={addTopic}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Topic title"
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {topics.map((t) => (
+          <li key={t.id}>
+            {t.title}
+            <button onClick={() => deleteTopic(t.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TopicManager;

--- a/admin/src/components/VideoManager.js
+++ b/admin/src/components/VideoManager.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { request } from '../api';
+
+function VideoManager({ token }) {
+  const [videos, setVideos] = useState([]);
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+
+  const load = async () => {
+    const res = await request('/api/videos');
+    if (res.ok) setVideos(await res.json());
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const addVideo = async (e) => {
+    e.preventDefault();
+    await request('/api/videos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, url })
+    });
+    setTitle('');
+    setUrl('');
+    load();
+  };
+
+  const deleteVideo = async (id) => {
+    await request(`/api/videos/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Videos</h2>
+      <form onSubmit={addVideo}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Video title"
+        />
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="Video URL"
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {videos.map((v) => (
+          <li key={v.id}>
+            {v.title} - {v.url}
+            <button onClick={() => deleteVideo(v.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default VideoManager;

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add React-based admin panel under `admin/`
- implement login with JWT token
- provide forms to manage courses, topics and videos

## Testing
- `npm test --prefix admin` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684016eb3b7c8328b5958f7b0f004b6a